### PR TITLE
Hint to GHC that indices are to be used strictly

### DIFF
--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -700,21 +700,25 @@ exchange v i x = checkIndex Bounds i (length v) $ unsafeExchange v i x
 -- | Yield the element at the given position. No bounds checks are performed.
 unsafeRead :: (PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> m a
 {-# INLINE unsafeRead #-}
-unsafeRead v i = checkIndex Unsafe i (length v)
+unsafeRead v !i = checkIndex Unsafe i (length v)
                $ stToPrim
                $ basicUnsafeRead v i
+-- Why do we need ! before i?
+-- The reason is that 'basicUnsafeRead' is a class member and, unless 'unsafeRead' was
+-- already specialised to a specific v, GHC has no clue that i is most certainly
+-- to be used eagerly. Bang before i hints this vital for optimizer information.
 
 -- | Replace the element at the given position. No bounds checks are performed.
 unsafeWrite :: (PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> a -> m ()
 {-# INLINE unsafeWrite #-}
-unsafeWrite v i x = checkIndex Unsafe i (length v)
+unsafeWrite v !i x = checkIndex Unsafe i (length v)
                   $ stToPrim
                   $ basicUnsafeWrite v i x
 
 -- | Modify the element at the given position. No bounds checks are performed.
 unsafeModify :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (a -> a) -> Int -> m ()
 {-# INLINE unsafeModify #-}
-unsafeModify v f i = checkIndex Unsafe i (length v)
+unsafeModify v f !i = checkIndex Unsafe i (length v)
                    $ stToPrim
                    $ basicUnsafeRead v i >>= \x ->
                      basicUnsafeWrite v i (f x)
@@ -725,7 +729,7 @@ unsafeModify v f i = checkIndex Unsafe i (length v)
 -- @since 0.12.3.0
 unsafeModifyM :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (a -> m a) -> Int -> m ()
 {-# INLINE unsafeModifyM #-}
-unsafeModifyM v f i = checkIndex Unsafe i (length v)
+unsafeModifyM v f !i = checkIndex Unsafe i (length v)
                     $ stToPrim . basicUnsafeWrite v i =<< f =<< stToPrim (basicUnsafeRead v i)
 
 -- | Swap the elements at the given positions. No bounds checks are performed.


### PR DESCRIPTION
### Description

In this pull request, several changes have been made in the `Data.Vector` module to add strictness annotations using the `!` symbol before function arguments in order to provide better optimization hints to the compiler.

- Added strictness annotation `!` before function arguments in certain functions to provide better optimization information to the compiler.
- Updated `(!)` and `(!?)` functions in `Data.Vector.Generic` and `Data.Vector.Generic.Mutable` modules to include strictness annotations before the arguments, improving optimization suggestions.

These changes aim to enhance the performance and efficiency of the functions by providing more optimization hints to the compiler through strictness annotations.